### PR TITLE
fix: wallet provider prop & viem dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "wagmi": "2.12.25",
-    "viem": "2.21.26"
+    "viem": "^2.21.26"
   },
   "devDependencies": {
     "@types/node": "20.11.30",

--- a/src/components/NextAbstractWalletProvider.tsx
+++ b/src/components/NextAbstractWalletProvider.tsx
@@ -9,7 +9,7 @@ export default function AbstractWalletWrapper({
   children: React.ReactNode;
 }) {
   return (
-    <AbstractWalletProvider config={{ chain: abstractTestnet }}>
+    <AbstractWalletProvider chain={abstractTestnet}>
       {children}
     </AbstractWalletProvider>
   );


### PR DESCRIPTION
Problems:
- AbstractWalletProvider's config prop type was incompatible with the constant imported from viem
- npm also had resolution conflict errors between the viem imported by the latest agw-client and the one imported by this package

Solution
- fix prop name
- change viem import so it pulls in the latest compatible version